### PR TITLE
Feat analyze

### DIFF
--- a/evaluate/analyze.go
+++ b/evaluate/analyze.go
@@ -1,24 +1,3 @@
-/// タイプ診断: 透明性､効率性の2軸評価
-/// 透明性の評価
-///   コード行数が短い
-///   命名平均長が長い
-///   関数の個数が多い
-///
-/// 効率性の評価
-///   トークン数が少ない
-///   ネストが浅い
-///   関数の個数が少ない
-
-/*
-type EvaluationResult struct {
-	lines             int
-	tokens            int
-	indent            Indent
-	functionCount     int
-	averageNameLength float32
-}
-*/
-
 package evaluate
 
 import (
@@ -40,9 +19,6 @@ const (
 const CORRECTION_FACTOR float32 = 0.5
 
 func Analyze(result *EvaluationResult, theme int) AnalysisResult {
-	//theme is difficulty, lower is easier, higher is harder
-
-	//透明性の評価
 	transparency := calcTransparency(theme, result.averageNameLength, result.lines, result.functionCount)
 	efficiency := calcEfficiency(theme, result.tokens, result.lines, result.functionCount)
 

--- a/evaluate/analyze.go
+++ b/evaluate/analyze.go
@@ -1,0 +1,99 @@
+/// タイプ診断: 透明性､効率性の2軸評価
+/// 透明性の評価
+///   コード行数が短い
+///   命名平均長が長い
+///   関数の個数が多い
+///
+/// 効率性の評価
+///   トークン数が少ない
+///   ネストが浅い
+///   関数の個数が少ない
+
+/*
+type EvaluationResult struct {
+	lines             int
+	tokens            int
+	indent            Indent
+	functionCount     int
+	averageNameLength float32
+}
+*/
+
+package evaluate
+
+import (
+	"encoding/json"
+	"io"
+	"math"
+	"os"
+)
+
+type AnalysisResult string
+
+const (
+	analyst    AnalysisResult = "analyst"
+	gatekeeper AnalysisResult = "gatekeeper"
+	diplomat   AnalysisResult = "diplomat"
+	artist     AnalysisResult = "artist"
+)
+
+const CORRECTION_FACTOR float32 = 0.5
+
+func Analyze(result *EvaluationResult, theme int) AnalysisResult {
+	//theme is difficulty, lower is easier, higher is harder
+
+	//透明性の評価
+	transparency := calcTransparency(theme, result.averageNameLength, result.lines, result.functionCount)
+	efficiency := calcEfficiency(theme, result.tokens, result.lines, result.functionCount)
+
+	if transparency > 0.5 && efficiency > 0.5 {
+		return analyst
+	} else if transparency > 0.5 && efficiency <= 0.5 {
+		return gatekeeper
+	} else if transparency <= 0.5 && efficiency > 0.5 {
+		return diplomat
+	} else {
+		return artist
+	}
+}
+
+func calcTransparency(theme int, averageNameLength float32, lines int, functionCount int) float32 {
+	transparency := averageNameLength - float32(lines) + float32(functionCount)
+	transparency = transparency + CORRECTION_FACTOR*difficulty(theme)
+	return float32(math.Tanh(float64(transparency)))
+}
+
+func calcEfficiency(theme, tokens int, lines int, functionCount int) float32 {
+	efficiency := float32(tokens) - float32(lines) - float32(functionCount)
+	efficiency = efficiency + CORRECTION_FACTOR*difficulty(theme)
+	return float32(math.Tanh(float64(efficiency)))
+}
+
+type Themes struct {
+	Themes []struct {
+		ID    int    `json:"id"`
+		Theme string `json:"theme"`
+	} `json:"themes"`
+}
+
+func difficulty(id int) float32 {
+	// load ../themes.json
+	f, err := os.Open("../themes.json")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	bytes, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	var theme Themes
+	if err := json.Unmarshal(bytes, &theme); err != nil {
+		panic(err)
+	}
+	length := len(theme.Themes)
+
+	return float32(1-id) / float32(length-1)
+}

--- a/evaluate/analyze_test.go
+++ b/evaluate/analyze_test.go
@@ -1,0 +1,74 @@
+package evaluate
+
+import (
+	"testing"
+)
+
+func TestAnalyze(t *testing.T) {
+	tests := []struct {
+		result       *EvaluationResult
+		theme        int
+		expectedType AnalysisResult
+	}{
+		{
+			result: &EvaluationResult{
+				lines:             5,
+				tokens:            10,
+				functionCount:     3,
+				averageNameLength: 10.0,
+			},
+			theme:        1,
+			expectedType: analyst,
+		},
+		{
+			result: &EvaluationResult{
+				lines:             5,
+				tokens:            7,
+				functionCount:     3,
+				averageNameLength: 15.0,
+			},
+			theme:        1,
+			expectedType: gatekeeper,
+		},
+		{
+			result: &EvaluationResult{
+				lines:             10,
+				tokens:            10,
+				functionCount:     1,
+				averageNameLength: 5.0,
+			},
+			theme:        3,
+			expectedType: artist,
+		},
+		{
+			result: &EvaluationResult{
+				lines:             10,
+				tokens:            20,
+				functionCount:     1,
+				averageNameLength: 5.0,
+			},
+			theme:        1,
+			expectedType: diplomat,
+		},
+	}
+
+	for _, test := range tests {
+		actualType := Analyze(test.result, test.theme)
+		if actualType != test.expectedType {
+			t.Errorf("Expected %v, but got %v", test.expectedType, actualType)
+		}
+	}
+}
+
+func TestCalcTransparency(t *testing.T) {
+	// 透明性の計算に対するテスト
+
+}
+
+func TestCalcEfficiency(t *testing.T) {
+	// 効率性の計算に対するテスト
+}
+
+func TestDifficulty(t *testing.T) {
+	// 難易度の計算に対するテスト
+}

--- a/evaluate/analyze_test.go
+++ b/evaluate/analyze_test.go
@@ -59,16 +59,3 @@ func TestAnalyze(t *testing.T) {
 		}
 	}
 }
-
-func TestCalcTransparency(t *testing.T) {
-	// 透明性の計算に対するテスト
-
-}
-
-func TestCalcEfficiency(t *testing.T) {
-	// 効率性の計算に対するテスト
-}
-
-func TestDifficulty(t *testing.T) {
-	// 難易度の計算に対するテスト
-}

--- a/evaluate/evaluate.go
+++ b/evaluate/evaluate.go
@@ -1,0 +1,10 @@
+package evaluate
+
+func Evaluate(theme int, code string, eval CodeEvaluator) *EvaluationResult {
+	result := eval.EvaluateAST(code)
+	result.lines = eval.CountLines(code)
+	result.tokens = eval.CountTokens(code)
+	result.indent = eval.CountNestedBlocks(code)
+
+	return result
+}

--- a/evaluate/go_evaluate.go
+++ b/evaluate/go_evaluate.go
@@ -97,7 +97,7 @@ func (e *GoEvaluator) EvaluateAST(targetAst interface{}) *EvaluationResult {
 	ast.Inspect(node, func(n ast.Node) bool {
 		switch n.(type) {
 		case *ast.FuncDecl:
-			result.FunctionCount++
+			result.functionCount++
 		case *ast.Ident:
 			tokenLen = append(tokenLen, len(n.(*ast.Ident).Name))
 		}
@@ -108,7 +108,7 @@ func (e *GoEvaluator) EvaluateAST(targetAst interface{}) *EvaluationResult {
 	for _, l := range tokenLen {
 		sum += l
 	}
-	result.AverageNameLength = float32(sum) / float32(len(tokenLen))
+	result.averageNameLength = float32(sum) / float32(len(tokenLen))
 
 	return result
 }

--- a/evaluate/go_evaluate_test.go
+++ b/evaluate/go_evaluate_test.go
@@ -82,10 +82,10 @@ func TestGoEvaluator_EvaluateAST_FuncCount(t *testing.T) {
 	}
 
 	result := evaluator.EvaluateAST(ast)
-	if result.FunctionCount != 3 {
-		t.Errorf("Expected 2 functions, but got %d", result.FunctionCount)
+	if result.functionCount != 3 {
+		t.Errorf("Expected 2 functions, but got %d", result.functionCount)
 	}
-	if result.AverageNameLength != 4.25 {
-		t.Errorf("Expected 4.5 average name length, but got %f", result.AverageNameLength)
+	if result.averageNameLength != 4.25 {
+		t.Errorf("Expected 4.5 average name length, but got %f", result.averageNameLength)
 	}
 }

--- a/evaluate/interface.go
+++ b/evaluate/interface.go
@@ -32,7 +32,9 @@ func (i IndentType) String() string {
 }
 
 type EvaluationResult struct {
-	FunctionCount     int
-	AverageNameLength float32
-	// snip...
+	lines             int
+	tokens            int
+	indent            Indent
+	functionCount     int
+	averageNameLength float32
 }

--- a/evaluate/interface.go
+++ b/evaluate/interface.go
@@ -2,9 +2,8 @@ package evaluate
 
 type CodeEvaluator interface {
 	CountLines(code string) int
-	CountNestedBlocks(code string) int
+	CountNestedBlocks(code string) Indent
 	CountTokens(code string) int
-	ParseToAST(code string) (interface{}, error)
 	EvaluateAST(ast interface{}) *EvaluationResult
 }
 

--- a/evaluate/python_evaluate_test.go
+++ b/evaluate/python_evaluate_test.go
@@ -57,10 +57,10 @@ func TestPythonEvaluator_CountFunctionCalls(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error: %s", err)
 	}
-	if result.FunctionCount != 2 {
-		t.Errorf("Expected 2, got %d", result.FunctionCount)
+	if result.functionCount != 2 {
+		t.Errorf("Expected 2, got %d", result.functionCount)
 	}
-	if result.AverageNameLength != 5.0 {
-		t.Errorf("Expected 4, got %f", result.AverageNameLength)
+	if result.averageNameLength != 5.0 {
+		t.Errorf("Expected 4, got %f", result.averageNameLength)
 	}
 }

--- a/evaluate/python_evalute.go
+++ b/evaluate/python_evalute.go
@@ -76,9 +76,9 @@ func (e *PythonEvaluator) EvaluateAST(code string) (EvaluationResult, error) {
 	result := EvaluationResult{}
 	out = out[:len(out)-2]
 	output := strings.Split(string(out), " ")
-	result.FunctionCount, err = strconv.Atoi(output[0])
+	result.functionCount, err = strconv.Atoi(output[0])
 	avarage, err := strconv.ParseFloat(output[1], 32)
-	result.AverageNameLength = float32(avarage)
+	result.averageNameLength = float32(avarage)
 	if err != nil {
 		return EvaluationResult{}, err
 	}


### PR DESCRIPTION
Close #6 

### What's Changed
- [x] こじつけタイプ診断機能の追加
- [x] APIハンドラーで利用可能な関数の追加

### Additional information
タイプ診断は､分析化､番人､外交官､芸術家の4タイプです､そのうち性質の似た言語でラベリングすることも検討
計算式と､難易度補正に関しては応相談 タイプによってはそんな書き方をする人が少ないがゆえにめったに出てくるタイプでない場合もあるので､偏ってるかどうかはあまり判断の材料にならないと思います｡